### PR TITLE
Fix QoS "EOIO"

### DIFF
--- a/com.equalize.xpi.af.modules.ejb/ejbModule/com/equalize/xpi/af/modules/AttachmentSplitterBean.java
+++ b/com.equalize.xpi.af.modules.ejb/ejbModule/com/equalize/xpi/af/modules/AttachmentSplitterBean.java
@@ -15,6 +15,7 @@ public class AttachmentSplitterBean extends AbstractModule {
 	private MessageDispatcher msgdisp;	
 	private String contentType;
 	private String qualityOfService;
+	private String sequenceId;
 	private boolean storeFileName;
 	private boolean filenameFromAttachmentName;
 	private String fileNameAttr;
@@ -28,6 +29,9 @@ public class AttachmentSplitterBean extends AbstractModule {
 			this.mode = this.param.getMandatoryParameter("mode");
 			this.param.checkParamValidValues("mode", "binding,channel");
 			this.qualityOfService = this.param.getMandatoryParameter("qualityOfService");
+			if (this.qualityOfService.equals("EOIO")){
+				this.sequenceId = this.param.getConditionallyMandatoryParameter("sequenceId", "qualityOfService", "EOIO");
+			}
 			this.param.checkParamValidValues("qualityOfService", "EO,EOIO,BE");
 			this.contentType = this.param.getParameter("contentType");
 			this.storeFileName = this.param.getBoolParameter("storeFileName", "N", false);
@@ -62,7 +66,12 @@ public class AttachmentSplitterBean extends AbstractModule {
 					count++;
 					Payload childPayload = iter.next();
 					// Create child message and set reference message ID
-					this.msgdisp.createMessage(childPayload.getContent(), getDeliverySemantics(this.qualityOfService));
+					if (this.qualityOfService.equals("EOIO")){
+						this.msgdisp.createMessage(childPayload.getContent(), getDeliverySemantics(this.qualityOfService), this.sequenceId);
+					}
+					else {
+						this.msgdisp.createMessage(childPayload.getContent(), getDeliverySemantics(this.qualityOfService));
+					}
 					this.msgdisp.setRefToMessageId(this.msg.getMessageId());
 					// Set child message content type
 					if(this.contentType == null) {

--- a/com.equalize.xpi.af.modules.ejb/ejbModule/com/equalize/xpi/af/modules/util/MessageDispatcher.java
+++ b/com.equalize.xpi.af.modules.ejb/ejbModule/com/equalize/xpi/af/modules/util/MessageDispatcher.java
@@ -74,10 +74,14 @@ public class MessageDispatcher {
 	}
 
 	public void createMessage(byte[] content, DeliverySemantics ds) throws NamingException, MessagingException {
-		createMessage(content, ds, "application/xml; charset=UTF-8");
+		createMessage(content, ds, "application/xml; charset=UTF-8", "");
+	}
+	
+	public void createMessage(byte[] content, DeliverySemantics ds, String sequenceId) throws NamingException, MessagingException {
+		createMessage(content, ds, "application/xml; charset=UTF-8", sequenceId);
 	}
 
-	public void createMessage(byte[] content, DeliverySemantics ds, String contentType) throws NamingException, MessagingException {					
+	public void createMessage(byte[] content, DeliverySemantics ds, String contentType, String sequenceId) throws NamingException, MessagingException {					
 		Party fp = new Party(this.fromParty);
 		Party tp = new Party(this.toParty);
 		Service fs = new Service(this.fromService);
@@ -91,6 +95,9 @@ public class MessageDispatcher {
 		// Create message with header details and QOS
 		this.msg = mf.createMessage(fp, tp, fs, ts, a);
 		this.msg.setDeliverySemantics(ds);
+		if (ds.equals(DeliverySemantics.ExactlyOnceInOrder)){
+			this.msg.setSequenceId(sequenceId);
+		}
 		// Create payload
 		this.payload = this.msg.createPayload();
 		// Set payload content and content type


### PR DESCRIPTION
For proper function of EOIO quality of service, it is necessary to set
sequencyId. Added sequenceId parameter to AttachmentSplitterBean and
implemented sequenceId support in message dispatcher.
